### PR TITLE
Restore ability to provide fault tolerance config without b64 encoded…

### DIFF
--- a/valeriano-manassero/trino/Chart.yaml
+++ b/valeriano-manassero/trino/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "433"
 description: High performance, distributed SQL query engine for big data
 name: trino
-version: 9.0.0
+version: 9.1.0
 kubeVersion: ">= 1.24.0-0 < 1.29.0-0"
 home: https://trino.io
 icon: https://trino.io/assets/images/trino-logo/trino-ko_tiny-alt.svg
@@ -27,4 +27,4 @@ keywords:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: modify JVM configurations to work with 433 version
+      description: restore ability to provide fault tolerance config without b64 encoded secret

--- a/valeriano-manassero/trino/README.md
+++ b/valeriano-manassero/trino/README.md
@@ -1,6 +1,6 @@
 # trino
 
-![Version: 9.0.0](https://img.shields.io/badge/Version-9.0.0-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
+![Version: 9.1.0](https://img.shields.io/badge/Version-9.1.0-informational?style=flat-square) ![AppVersion: 433](https://img.shields.io/badge/AppVersion-433-informational?style=flat-square)
 
 High performance, distributed SQL query engine for big data
 
@@ -89,6 +89,7 @@ Kubernetes: `>= 1.24.0-0 < 1.29.0-0`
 | connectors | object | `{}` |  |
 | containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | SecurityContext configuration for containers |
 | eventListenerProperties | object | `{}` |  |
+| faultTolerance.configAsSecret | bool | `true` |  |
 | faultTolerance.enabled | bool | `false` |  |
 | fullnameOverride | string | `"trino"` |  |
 | groupProvider | object | `{}` |  |

--- a/valeriano-manassero/trino/templates/configmap-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/configmap-coordinator.yaml
@@ -102,6 +102,12 @@ data:
 {{ .Values.groupProvider.customProperties | indent 4 }}
 {{- end }}{{- end }}
 
+{{- if .Values.faultTolerance.enabled }}{{- if not .Values.faultTolerance.configAsSecret }}
+  exchange-manager.properties: |
+    exchange-manager.name=filesystem
+{{ .Values.faultTolerance.properties | indent 4 }}
+{{- end }}{{- end }}
+
 {{ if .Values.eventListenerProperties }}
   event-listener.properties: |
   {{- range $configValue := .Values.eventListenerProperties }}

--- a/valeriano-manassero/trino/templates/configmap-worker.yaml
+++ b/valeriano-manassero/trino/templates/configmap-worker.yaml
@@ -52,6 +52,12 @@ data:
   log.properties: |
     io.trino={{ .Values.config.general.log.trino.level }}
 
+{{- if .Values.faultTolerance.enabled }}{{- if not .Values.faultTolerance.configAsSecret }}
+  exchange-manager.properties: |
+    exchange-manager.name=filesystem
+{{ .Values.faultTolerance.properties | indent 4 }}
+{{- end }}{{- end }}
+
 {{ if .Values.eventListenerProperties }}
   event-listener.properties: |
   {{- range $configValue := .Values.eventListenerProperties }}

--- a/valeriano-manassero/trino/templates/deployment-coordinator.yaml
+++ b/valeriano-manassero/trino/templates/deployment-coordinator.yaml
@@ -34,7 +34,7 @@ spec:
             - configMap:
                 name: {{ template "trino.coordinator" . }}
 
-            {{- if .Values.faultTolerance.enabled }}
+            {{- if and .Values.faultTolerance.enabled .Values.faultTolerance.configAsSecret }}
             - secret:
                 name: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
             {{- end }}

--- a/valeriano-manassero/trino/templates/deployment-worker.yaml
+++ b/valeriano-manassero/trino/templates/deployment-worker.yaml
@@ -35,7 +35,7 @@ spec:
             - configMap:
                 name: {{ template "trino.worker" . }}
 
-            {{- if .Values.faultTolerance.enabled }}
+            {{- if and .Values.faultTolerance.enabled .Values.faultTolerance.configAsSecret }}
             - secret:
                 name: {{ .Values.faultToleranceSecret | default "trino-fault-tolerance" }}
             {{- end }}

--- a/valeriano-manassero/trino/templates/secret.yaml
+++ b/valeriano-manassero/trino/templates/secret.yaml
@@ -23,7 +23,7 @@ data:
   password.db: {{ .Values.auth.passwordAuth | b64enc }}
 {{- end }}{{- end }}{{- end }}
 ---
-{{- if .Values.faultTolerance.enabled }}{{- if not .Values.faultToleranceSecret }}
+{{- if and .Values.faultTolerance.enabled .Values.faultTolerance.configAsSecret (not .Values.faultToleranceSecret)}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -33,4 +33,4 @@ metadata:
 data:
   exchange-manager.properties: |
     {{ .Values.faultTolerance.properties | b64enc }}
-{{- end }}{{- end }}
+{{- end }}

--- a/valeriano-manassero/trino/values.yaml
+++ b/valeriano-manassero/trino/values.yaml
@@ -353,6 +353,7 @@ groupProvider: {}
 
 faultTolerance:
   enabled: false
+  configAsSecret: true
   # properties: |-
   #   exchange-manager.name=filesystem
   #   exchange.base-directories=s3://<bucket-name>


### PR DESCRIPTION
… secret (#195)

* configAsSecret for fault tolerance

* chart and readme update

* condition for volumes as well

**What this PR does / why we need it**:


**Checklist**
- [ ] Reviewed the [`CONTRIBUTING.md`](https://github.com/valeriano-manassero/helm-charts/blob/main/CONTRIBUTING.md#pull-requests) guide (**required**)
- [ ] Verify the work you plan to merge addresses an existing [issue](https://github.com/valeriano-manassero/helm-charts/issues) (If not, open a new one) (**required**)
- [ ] Check your branch with `helm lint` (**required**)
- [ ] Update `version` in `Chart.yaml` according [semver](https://semver.org/) rules (**required**)
- [ ] Substitute `annotations` section in `Chart.yaml` annotating implementations (useful for Artifacthub changelog) (**required**)
- [ ] Update chart README using [helm-docs](https://github.com/norwoodj/helm-docs) (**required**)


**Which issue(s) this PR fixes**:

Fixes #<issue number>

**Special notes for your reviewer**:
